### PR TITLE
Network index is off by 1 on HP Cloud

### DIFF
--- a/lib/vagrant-openstack-plugin/action/create_server.rb
+++ b/lib/vagrant-openstack-plugin/action/create_server.rb
@@ -68,7 +68,7 @@ module VagrantPlugins
                 # Match the OpenStack network to a corresponding
                 # config.vm.network option.  If there is one, use that for its
                 # IP address.
-                config_network = env[:machine].config.vm.networks[i]
+                config_network = env[:machine].config.vm.networks[i+1]
                 if config_network
                   ip_address = config_network[1][:ip]
                   current[:v4_fixed_ip] = ip_address if ip_address


### PR DESCRIPTION
Testing on HP Cloud showed that the network index used was off by 1.

Bump it so that the plugin works correctly with HP Cloud.