### PR TITLE
Selecting IP with specified address family from multiple addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Vagrant.configure("2") do |config|
     os.keypair_name = "YOUR KEYPAIR NAME"      # as stored in Nova
     os.ssh_username = "SSH USERNAME"           # login for the VM
 
+    os.ssh_ip_family = "ipv6"                  # IP address family
+
     os.metadata  = {"key" => "value"}                      # optional
     os.user_data = "#cloud-config\nmanage_etc_hosts: True" # optional
     os.network            = "YOUR NETWORK_NAME"            # optional
@@ -89,7 +91,7 @@ Vagrant.configure("2") do |config|
     os.orchestration_cfn_template_file = '/tmp/cfn_heat_template.json'	# optional
     os.orchestration_cfn_template_parameters = {			# optional
       'NetworkName' => 'net_01'
-    } 
+    }
   end
 end
 ```
@@ -133,7 +135,9 @@ This provider exposes quite a few provider-specific configuration options:
 * `username` - The username with which to access OpenStack.
 * `keypair_name` - The name of the keypair to access the machine.
 * `ssh_username` - The username to access the machine. This can also be
-  configured using the standard config.ssh.username configuration value.
+configured using the standard config.ssh.username configuration value.
+* `ssh_ip_family` - The IP address family to use for SSH connection. It could be `ipv6` or `ipv4`.
+This option takes effect only if virtual machine have multiple addresses.
 * `metadata` - A set of key pair values that will be passed to the instance
   for configuration.
 * `network` - A name or id that will be used to fetch network configuration
@@ -141,8 +145,8 @@ This provider exposes quite a few provider-specific configuration options:
   vagrant network configurations.
 * `networks` - An array of names or ids to create a server with multiple network interfaces. This overrides the `network` setting.
 * `address_id` - A specific address identifier to use when connecting to the
-  instance. `network` has higher precedence. If set to :floating_ip, then 
-  the floating IP address will be used. 
+  instance. `network` has higher precedence. If set to :floating_ip, then
+  the floating IP address will be used.
 * `scheduler_hints` - Pass hints to the open stack scheduler, see `--hint` flag in [OpenStack filters doc](http://docs.openstack.org/trunk/openstack-compute/admin/content/scheduler-filters.html)
 * `availability_zone` - Specify the availability zone in which the instance
   must be created.

--- a/lib/vagrant-openstack-plugin/action/read_ssh_info.rb
+++ b/lib/vagrant-openstack-plugin/action/read_ssh_info.rb
@@ -1,4 +1,5 @@
 require "log4r"
+require "ipaddr"
 
 module VagrantPlugins
   module OpenStack
@@ -64,8 +65,20 @@ module VagrantPlugins
               end
             elsif server.private_ip_addresses.length > 0
               @logger.debug("Private IP addresses available: #{server.private_ip_addresses}")
-              host = server.private_ip_address
-              @logger.debug("Using the first available private IP address: #{host}.")
+              puts config.ssh_ip_family
+              if config.ssh_ip_family.nil?
+                host = server.private_ip_address
+                @logger.debug("Using the first available private IP address: #{host}.")
+              else
+                for ip in server.private_ip_addresses
+                  addr = IPAddr.new ip
+                  if addr.send("#{config.ssh_ip_family}?".to_sym)
+                    host = ip.to_s
+                    @logger.debug("Using the first available #{config.ssh_ip_family} IP address: #{host}.")
+                    break
+                  end
+                end
+              end
             end
           end
 

--- a/lib/vagrant-openstack-plugin/action/read_ssh_info.rb
+++ b/lib/vagrant-openstack-plugin/action/read_ssh_info.rb
@@ -65,7 +65,6 @@ module VagrantPlugins
               end
             elsif server.private_ip_addresses.length > 0
               @logger.debug("Private IP addresses available: #{server.private_ip_addresses}")
-              puts config.ssh_ip_family
               if config.ssh_ip_family.nil?
                 host = server.private_ip_address
                 @logger.debug("Using the first available private IP address: #{host}.")

--- a/lib/vagrant-openstack-plugin/config.rb
+++ b/lib/vagrant-openstack-plugin/config.rb
@@ -68,6 +68,11 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :ssh_username
 
+      # The IP address family that will be used to connect to the instance
+      #
+      # @return [String]
+      attr_accessor :ssh_ip_family
+
       # A Hash of metadata that will be sent to the instance for configuration
       #
       # @return [Hash]
@@ -137,6 +142,7 @@ module VagrantPlugins
         @availability_zone = UNSET_VALUE
         @security_groups = UNSET_VALUE
         @ssh_username = UNSET_VALUE
+        @ssh_ip_family = UNSET_VALUE
         @tenant = UNSET_VALUE
         @user_data = UNSET_VALUE
         @floating_ip = UNSET_VALUE
@@ -175,6 +181,7 @@ module VagrantPlugins
         # The SSH values by default are nil, and the top-level config
         # `config.ssh` values are used.
         @ssh_username = nil if @ssh_username == UNSET_VALUE
+        @ssh_ip_family = nil if @ssh_ip_family == UNSET_VALUE
 
         @tenant = nil if @tenant == UNSET_VALUE
         @user_data = "" if @user_data == UNSET_VALUE


### PR DESCRIPTION
There is no way to control what IP address will be selected if virtual machine have more than one address.
That could be a problem if a virtual machine have IPv4 and IPv6 addresses, but machine that runs vagrant have only IPv4 address. If IPv6 address will be first the SSH connection would not been achieved.