### PR TITLE
Ensure floating IP configuration is honored when floating IP pool is not set

### DIFF
--- a/lib/vagrant-openstack-plugin/config.rb
+++ b/lib/vagrant-openstack-plugin/config.rb
@@ -179,7 +179,7 @@ module VagrantPlugins
         @tenant = nil if @tenant == UNSET_VALUE
         @user_data = "" if @user_data == UNSET_VALUE
         @floating_ip = nil if @floating_ip == UNSET_VALUE
-        @floating_ip = nil if @floating_ip_pool == UNSET_VALUE
+        @floating_ip_pool = nil if @floating_ip_pool == UNSET_VALUE
 
         @disks = nil if @disks == UNSET_VALUE
 


### PR DESCRIPTION
This addresses the bug referenced in issue #100, where the configuration for a floating IP is incorrectly ignored when the floating IP pool is not set.