### PR TITLE
Association of pre-allocated floating IP's in a given pool.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ Vagrant.configure("2") do |config|
     os.availability_zone  = "az0001"           # optional
     os.security_groups    = ['ssh', 'http']    # optional
     os.tenant             = "YOUR TENANT_NAME" # optional
-    os.floating_ip        = "33.33.33.33"      # optional (The floating IP to assign for this instance, or set to :auto)
-    os.floating_ip_pool   = "public"           # optional (The floating IP pool to allocate addresses from, if floating_ip = :auto)
+    os.floating_ip        = "33.33.33.33"      # optional (The floating IP to assign for this instance, or set to :auto or :associate_unassigned)
+    os.floating_ip_pool   = "public"           # optional (The floating IP pool to allocate addresses to, if floating_ip = :auto, or the pool to pull the next available IP from if floating_ip = :associate_unassigned)
 
     os.disks              = [                  # optional
                              {"name" => "volume_name_here", "description" => "A 10GB Volume", "size" => 10},
@@ -152,7 +152,7 @@ This provider exposes quite a few provider-specific configuration options:
 * `proxy` - HTTP proxy. When behind a firewall override this value for API access.
 * `ssl_verify_peer` - sets the ssl_verify_peer on the underlying excon connection - useful for self signed certs etc.
 * `floating_ip` - Floating ip. The floating IP to assign for this instance. If
-  set to :auto, then this assigns any available floating IP to the instance.
+  set to :auto, then this assigns any available floating IP to the instance. If set to :associate_unassigned, then it will use the next IP address which is unasssigned in the pool specified in floating_ip_pool.
 * `floating_ip_pool` - Floating ip pool to allocate IP addresses from, if
   floating_ip is set to :auto.  Previously allocated addresses will not be
   used, and addresses allocated here will be released when the VM is destroyed.

--- a/lib/vagrant-openstack-plugin/errors.rb
+++ b/lib/vagrant-openstack-plugin/errors.rb
@@ -43,6 +43,18 @@ module VagrantPlugins
         error_key(:floating_ip_not_allocated)
       end
 
+      class FloatingUnassignedIPNotFound < VagrantOpenStackError
+        error_key(:floating_unassigned_ip_not_found)
+      end
+
+      class FloatingIPFailedAssociate < VagrantOpenStackError
+        error_key(:floating_ip_failed_associate)
+      end
+
+      class FloatingUnassignedRequiresPool < VagrantOpenStackError
+        error_key(:floating_unassigned_requires_pool)
+      end
+
       class OrchestrationTemplateError < VagrantOpenStackError
         error_key(:orchestration_template_error)
       end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -112,6 +112,12 @@ en:
         IPs were found in OpenStack
       floating_ip_not_allocated: |-
         A floating IP could not be allocated from the pool.
+      floating_unassigned_ip_not_found: |-
+        An unassigned floating IP could not be found in the specified pool.
+      floating_ip_failed_associate: |-
+        The selected IP failed to associate
+      floating_unassigned_requires_pool: |-
+        You must specifiy a pool in floating_ip_pool when using associate_unassigned
       orchestration_template_error: |-
         There was an error while reading orchestration template.
         Error: %{err}


### PR DESCRIPTION
I've implemented this as os.floating_ip :associate_unassigned, as an alternative to os.floating_ip :auto.  Let me know if you prefer a different label. os.floating_ip_pool tag is re-used.

This was necessary in our environment where we have blocks of IPs associated with firewall rules - new IP's cannot simply be allocated to the pool every time - if we can't get an IP from the requested pool, it shouldn't get an IP at all (until one can be assigned manually later).

I think this is a fairly common use-case - Thanks!

Also - solves https://github.com/cloudbau/vagrant-openstack-plugin/issues/112 more or less.