### PR TITLE
Fix undefined method `display_name' during delete

### DIFF
--- a/lib/vagrant-openstack-plugin/action/delete_server.rb
+++ b/lib/vagrant-openstack-plugin/action/delete_server.rb
@@ -63,7 +63,7 @@ module VagrantPlugins
               volumes.each do |compute_volume|
                 volume = env[:openstack_volume].volumes.get(compute_volume["id"])
                 if volume
-                  env[:ui].info("Deleting volume: #{volume.display_name}")
+                  env[:ui].info("Deleting volume: #{volume.id}")
                   begin
                     volume.destroy
                   rescue Excon::Errors::Error => e


### PR DESCRIPTION
Volumes can be nameless.  When trying to delete one such volume, refer
to the ID instead of the name.  This can also help make things more
clear if there are multiple volumes with the same name.