### PR TITLE
Fix deleting floater IPs

### DIFF
--- a/lib/vagrant-openstack-plugin/action/delete_server.rb
+++ b/lib/vagrant-openstack-plugin/action/delete_server.rb
@@ -52,7 +52,7 @@ module VagrantPlugins
                 end
               end
 
-              if machine.provider_config.floating_ip_pool && machine.provider_config.floating_ip == ":auto"
+              if machine.provider_config.floating_ip_pool && machine.provider_config.floating_ip.to_s == 'auto'
                 address = env[:openstack_compute].list_all_addresses.body["floating_ips"].find{|i| i["ip"] == ip}
                 if address
                   env[:openstack_compute].release_address(address["id"])


### PR DESCRIPTION
The floating IPs were not being deleted because
machine.provider_config.floating_ip is a symbol and doing string
comparison on the symbol was not working properly.  This patch properly
converts the symbol to a string before comparing, thus ensuring that
ruby can actually match to the string.