### PR TITLE
Support for Keystone V3 API added.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,16 @@ Vagrant.configure("2") do |config|
   config.ssh.private_key_path = "~/.ssh/id_rsa"
 
   config.vm.provider :openstack do |os|
-    os.username     = "YOUR USERNAME"          # e.g. "#{ENV['OS_USERNAME']}"
-    os.api_key      = "YOUR API KEY"           # e.g. "#{ENV['OS_PASSWORD']}"
-    os.flavor       = /m1.tiny/                # Regex or String
-    os.image        = /Ubuntu/                 # Regex or String
-    os.endpoint     = "KEYSTONE AUTH URL"      # e.g. "#{ENV['OS_AUTH_URL']}/tokens"
-    os.keypair_name = "YOUR KEYPAIR NAME"      # as stored in Nova
-    os.ssh_username = "SSH USERNAME"           # login for the VM
+    os.username       = "YOUR USERNAME"          # e.g. "#{ENV['OS_USERNAME']}"
+    os.api_key        = "YOUR API KEY"           # e.g. "#{ENV['OS_PASSWORD']}"
+    os.flavor         = /m1.tiny/                # Regex or String
+    os.image          = /Ubuntu/                 # Regex or String
+    os.endpoint       = "KEYSTONE AUTH URL"      # e.g. "#{ENV['OS_AUTH_URL']}/tokens"
+    os.project_name   = "PROJECT NAME"           # required when using Keystone V3
+    os.project_domain = "PROJECT DOMAIN NAME"    # required when using Keystone V3
+    os.user_domain    = "USER DOMAIN NAME"       # required when using Keystone V3
+    os.keypair_name   = "YOUR KEYPAIR NAME"      # as stored in Nova
+    os.ssh_username   = "SSH USERNAME"           # login for the VM
 
     os.ssh_ip_family = "ipv6"                  # IP address family
 

--- a/lib/vagrant-openstack-plugin/action/connect_openstack.rb
+++ b/lib/vagrant-openstack-plugin/action/connect_openstack.rb
@@ -21,6 +21,9 @@ module VagrantPlugins
           username = config.username
           tenant = config.tenant
           region = config.region
+          project_name = config.project_name
+          project_domain = config.project_domain
+          user_domain = config.user_domain
 
           # Pass proxy config down into the Fog::Connection object using
           # the `connection_options` hash.
@@ -32,13 +35,16 @@ module VagrantPlugins
           # Prepare connection parameters for use with fog service
           # initialization (compute, storage, orchestration, ...).
           env[:fog_openstack_params] = {
-            :provider           => :openstack,
+            :provider => :openstack,
             :connection_options => connection_options,
             :openstack_username => username,
-            :openstack_api_key  => api_key,
+            :openstack_api_key => api_key,
             :openstack_auth_url => endpoint,
-            :openstack_tenant   => tenant,
-            :openstack_region   => region
+            :openstack_tenant => tenant,
+            :openstack_region => region,
+            :openstack_project_name => project_name,
+            :openstack_project_domain => project_domain,
+            :openstack_user_domain => user_domain
           }
 
           @logger.info("Connecting to OpenStack...")
@@ -54,7 +60,10 @@ module VagrantPlugins
               :openstack_api_key => api_key,
               :openstack_auth_url => endpoint,
               :openstack_tenant => tenant,
-              :openstack_region => region
+              :openstack_region => region,
+              :openstack_project_name => project_name,
+              :openstack_project_domain => project_domain,
+              :openstack_user_domain => user_domain
             })
           end
 
@@ -66,7 +75,10 @@ module VagrantPlugins
               :openstack_api_key => api_key,
               :openstack_auth_url => endpoint,
               :openstack_tenant => tenant,
-              :openstack_region => region
+              :openstack_region => region,
+              :openstack_project_name => project_name,
+              :openstack_project_domain => project_domain,
+              :openstack_user_domain => user_domain
             })
           end
 

--- a/lib/vagrant-openstack-plugin/config.rb
+++ b/lib/vagrant-openstack-plugin/config.rb
@@ -104,6 +104,21 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :region
 
+      # The region to specify when the OpenStack cloud has multiple regions
+      #
+      # @return [String]
+      attr_accessor :project_name
+
+      # The region to specify when the OpenStack cloud has multiple regions
+      #
+      # @return [String]
+      attr_accessor :project_domain
+
+      # The region to specify when the OpenStack cloud has multiple regions
+      #
+      # @return [String]
+      attr_accessor :user_domain
+
       # The proxy to specify when making connection to OpenStack API.
       #
       # @return [String]
@@ -148,6 +163,9 @@ module VagrantPlugins
         @floating_ip = UNSET_VALUE
         @floating_ip_pool = UNSET_VALUE
         @region = UNSET_VALUE
+        @project_name = UNSET_VALUE
+        @project_domain = UNSET_VALUE
+        @user_domain = UNSET_VALUE
         @proxy = UNSET_VALUE
         @ssl_verify_peer = UNSET_VALUE
         @disks = UNSET_VALUE
@@ -187,6 +205,11 @@ module VagrantPlugins
         @user_data = "" if @user_data == UNSET_VALUE
         @floating_ip = nil if @floating_ip == UNSET_VALUE
         @floating_ip_pool = nil if @floating_ip_pool == UNSET_VALUE
+
+        @region = nil if @region == UNSET_VALUE
+        @project_name = nil if @project_name == UNSET_VALUE
+        @project_domain = nil if @project_domain == UNSET_VALUE
+        @user_domain = nil if @user_domain == UNSET_VALUE
 
         @disks = nil if @disks == UNSET_VALUE
 


### PR DESCRIPTION
The current plugin cannot be used with OpenStack Mitaka. Requests fail with the message "401 Unauthorized". By specifying "project_name", "project_domain" and "user_domain" and a Keystone v3 endpoint, the authorization process succeeds.